### PR TITLE
Refactor signup_view

### DIFF
--- a/hysterical-horses/code_jam/users/templates/users/signup.html
+++ b/hysterical-horses/code_jam/users/templates/users/signup.html
@@ -20,6 +20,10 @@
             <label>{{ field.label }}</label>
             {{ field|addclass:"nes-input" }}
         </div>
+
+        {% for error in field.errors %}
+            <p>{{ error }}</p>
+        {% endfor %}
         {% endfor %}
 
         <input class="nes-btn is-success" type="submit" value="Signup">

--- a/hysterical-horses/code_jam/users/urls.py
+++ b/hysterical-horses/code_jam/users/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     path("profile/", views.profile, name="profile"),
     path("login/", LoginView.as_view(template_name='users/login.html'), name='login'),
     path("logout/", LogoutView.as_view(template_name='users/logout.html'), name='logout'),
-    path("signup/", views.signup, name="signup"),
+    path("signup/", views.signup_view, name="signup"),
 ]

--- a/hysterical-horses/code_jam/users/views.py
+++ b/hysterical-horses/code_jam/users/views.py
@@ -10,18 +10,16 @@ def profile(request):
     return render(request, "users/profile.html", context)
 
 
-def signup(request):
-    if request.method == 'POST':
-        form = UserCreationForm()
-        if form.is_valid():
-            form.save()
-            username = form.cleaned_data.get('username')
-            raw_password = form.cleaned_data.get('password1')
-            user = authenticate(username=username, password=raw_password)
-            login(request, user)
-            return redirect('home')
-    else:
-        form = UserCreationForm()
+def signup_view(request):
+    form = UserCreationForm(request.POST or None)
+
+    if form.is_valid():
+        form.save()
+        username = form.cleaned_data.get('username')
+        raw_password = form.cleaned_data.get('password1')
+        user = authenticate(username=username, password=raw_password)
+        login(request, user)  # Immediately log the user in
+        return redirect('dashboard-index')
 
     context = {'form': form}
     return render(request, 'users/signup.html', context)


### PR DESCRIPTION
- `signup` view name changed to `signup_view` to meet Django conventions
- Refactored `signup_view`
- User is now redirected to the dashboard after a successful sign up
- `signup.html` now display error messages from the form